### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A Model Context Protocol integration for Zonos TTS, allowing Claude to generate speech directly.
 
+<a href="https://glama.ai/mcp/servers/clybepate4"><img width="380" height="200" src="https://glama.ai/mcp/servers/clybepate4/badge" alt="Zonos TTS Server MCP server" /></a>
+
 ## Setup
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [Zonos TTS MCP Server](https://glama.ai/mcp/servers/clybepate4) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/clybepate4"><img width="380" height="200" src="https://glama.ai/mcp/servers/clybepate4/badge" alt="Zonos TTS Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.